### PR TITLE
Updated to Laravel 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.9",
         "illuminate/support": "5.1.*",
         "nqxcode/zendsearch": "dev-master",
         "nqxcode/lucene-stemmer-en-ru": "1.*"

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*",
+        "illuminate/support": "5.1.*",
         "nqxcode/zendsearch": "dev-master",
         "nqxcode/lucene-stemmer-en-ru": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*",
         "mockery/mockery": "0.9.*",
-        "orchestra/testbench": "3.0.*"
+        "orchestra/testbench": "3.1.*"
     },
     "autoload": {
         "files": [

--- a/src/Nqxcode/LuceneSearch/Console/RebuildCommand.php
+++ b/src/Nqxcode/LuceneSearch/Console/RebuildCommand.php
@@ -5,6 +5,7 @@ use Nqxcode\LuceneSearch\Search;
 
 use App;
 use Config;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\NullOutput;
 
 class RebuildCommand extends Command
@@ -36,9 +37,8 @@ class RebuildCommand extends Command
                 $count = count($all);
 
                 if ($count > 0) {
-                    /** @var \Symfony\Component\Console\Helper\ProgressBar $progress */
-                    $progress = $this->getHelperSet()->get('progress');
-                    $progress->start($this->getOutput(), $count);
+                    /** @var ProgressBar $progress */
+                    $progress = new ProgressBar($this->getOutput(), $count);
 
                     foreach ($all as $model) {
                         $search->update($model);


### PR DESCRIPTION
Only problem was a bug in symfony, $progress = $this->getHelperSet()->get('progress'); gave a deprecation exception that you should use the ProgressBar instead. Although that exception is caused by their own code as you can see here:

https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Console/Application.php#L958

When symfony fixed this, the line could be reverted.

Edit: extra commit, laravel 5.1 requires php 5.5.9, that's why travis fails