### PR TITLE
Group queries by table

### DIFF
--- a/src/Nqxcode/LuceneSearch/Support/Collection.php
+++ b/src/Nqxcode/LuceneSearch/Support/Collection.php
@@ -36,4 +36,5 @@ class Collection extends \Illuminate\Database\Eloquent\Collection
         }
 
         return $this;
+    }
 }


### PR DESCRIPTION
If the search returned 30 hits for the same table, 30 DB queries would be executed. I've changed the code so queries to the same table are grouped, only one per table.
