### PR TITLE
Fixed eloquent builder "lists()" call

### DIFF
--- a/src/Nqxcode/LuceneSearch/Model/Config.php
+++ b/src/Nqxcode/LuceneSearch/Model/Config.php
@@ -153,12 +153,13 @@ class Config
         $groupedIdsAsKeys = [];
 
         foreach ($this->classUidList($hits) as $classUid) {
-            /** @var Model|Builder $model */
+            /** @var Model $model */
             $model = $this->newInstanceBy($classUid);
+            $builder = $model->newQuery();
             $primaryKey = $model->getKeyName();
 
             if (!method_exists($model, 'searchableIds')) { // If not exists get full id list
-                $searchableIds = $model->lists($primaryKey);
+                $searchableIds = $builder->lists($primaryKey);
             } else {
                 $searchableIds = $model->{'searchableIds'}();
             }


### PR DESCRIPTION
When dealing with a model that has a "lists" method, that method will be called instead of Eloquent Builder's lists method