### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Or/and in model accessor:
         }
 ```
 
-###Stemming and stopwords
+### Stemming and stopwords
 By default the following filters are used in search:
 - Stemming filter for **english/russian** words (for reducing words to their root form),
 - Stopword filters for **english/russian** words (for exclude some words from search index).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
