### PR TITLE
Port to Laravel 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 7.0
+  - 7.1
+  - 7.2
 
 env:
   global:
@@ -12,7 +14,7 @@ before_script:
   - travis_retry composer self-update
   - composer config discard-changes true
   - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-stable; fi
-  - if [[ $setup = 'coveralls' ]]; then travis_retry composer require "psr/log=1.0.0" "satooshi/php-coveralls=~0.6" "symfony/yaml=~2.0" --prefer-source --no-interaction --dev; fi
+  - if [[ $setup = 'coveralls' ]]; then travis_retry composer require "psr/log=1.0.0" "php-coveralls/php-coveralls=~2.1" "symfony/yaml=~3.3" --prefer-source --no-interaction --dev; fi
 
 script:
   - if [[ $coverage = 'yes' ]]; then phpunit -c phpunit.xml --coverage-clover build/logs/clover.xml; fi
@@ -24,4 +26,8 @@ after_script:
 matrix:
   include:
     - php: 7.0
+      env: setup=coveralls coverage=yes
+    - php: 7.1
+      env: setup=coveralls coverage=yes
+    - php: 7.2
       env: setup=coveralls coverage=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 5.6
+  - 7.0
 
 env:
   global:
@@ -23,5 +23,5 @@ after_script:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.0
       env: setup=coveralls coverage=yes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Laravel 5.4 Lucene search
+Laravel 5.5 Lucene search
 ==============
 
 [![Latest Stable Version](https://poser.pugx.org/nqxcode/laravel-lucene-search/v/stable.png)](https://packagist.org/packages/nqxcode/laravel-lucene-search)
@@ -7,7 +7,7 @@ Laravel 5.4 Lucene search
 [![Build Status](https://travis-ci.org/nqxcode/laravel-lucene-search.svg?branch=master)](https://travis-ci.org/nqxcode/laravel-lucene-search)
 [![Coverage Status](https://img.shields.io/coveralls/nqxcode/laravel-lucene-search/master.svg?style=flat)](https://coveralls.io/r/nqxcode/laravel-lucene-search?branch=master)
 
-Laravel 5.4 package for full-text search over Eloquent models based on ZendSearch Lucene.
+Laravel 5.5 package for full-text search over Eloquent models based on ZendSearch Lucene.
 
 ## Installation
 
@@ -36,7 +36,7 @@ If you want to use the facade to search, add this to your facades in `config/app
 	'Search' => Nqxcode\LuceneSearch\Facade::class,
 ],
 ```
-## Configuration 
+## Configuration
 
 Publish the config file into your project by running:
 
@@ -48,7 +48,7 @@ In published config file add descriptions for models which need to be indexed, f
 
 ```php
 'index' => [
-	
+
 	// ...
 
 	namespace\FirstModel::class => [
@@ -56,13 +56,13 @@ In published config file add descriptions for models which need to be indexed, f
 			'name', 'full_description', // fields for indexing
 		]
 	],
-	
+
 	namespace\SecondModel::class => [
 		'fields' => [
 			'name', 'short_description', // fields for indexing
 		]
 	],
-	
+
 	namespace\ModelWithCustomPrimaryKey::class => [
 		// You can also define your primary key (if you use something else than "id")
 		'primary_key' => 'my_custom_field_name',
@@ -70,9 +70,9 @@ In published config file add descriptions for models which need to be indexed, f
 			'username', 'short_description', // fields for indexing
 		]
 	],
-	
+
 	// ...
-	
+
 ],
 
 ```
@@ -82,9 +82,9 @@ You can also index values of **optional fields** (dynamic fields). For enable in
 - In config for each necessary model add following option:
 ```php
         'optional_attributes' => true
-        
+
         // or
-        
+
         'optional_attributes' => [
                 'accessor' => 'custom_name' // with specifying of accessor name
         ]
@@ -127,9 +127,9 @@ This is **Document level boosting** in terminology of Apache Lucene. By default 
 - In config for each necessary model add following option:
 ```php
         'boost' => true
-        
+
         // or
-        
+
         'boost' => [
                 'accessor' => 'custom_name' // with specifying of accessor name
         ]
@@ -155,7 +155,7 @@ In config file:
                 'fields' => [
                     'name', 'full_description',
                 ],
-                
+
                 'boost' => true // enable boosting for model
         ],
 ```
@@ -208,11 +208,11 @@ This filters can be deleted or replaced with others.
     	// Default stemming filter.
     	Nqxcode\Stemming\TokenFilterEnRu::class,
     ],
-        
-    // List of paths to files with stopwords. 
+
+    // List of paths to files with stopwords.
     'stopwords' => Nqxcode\LuceneSearch\Analyzer\Stopwords\Files::get(),
 ],
-    
+
 ```
 
 ## Usage
@@ -229,7 +229,7 @@ For clearing of search index run:
 ```bash
 php artisan search:clear
 ```
-#### Filtering of models in search results 
+#### Filtering of models in search results
 For filtering of models in search results each model's class can implements `SearchableInterface`.
 For example:
 
@@ -267,7 +267,7 @@ For register of necessary events (save/update/delete) `use Nqxcode\LuceneSearch\
     class Dummy extends Model implements SearchableInterface
     {
         use SearchTrait;
-    
+
         // ...
     }
 
@@ -296,11 +296,11 @@ By default, queries which will execute search in the **phrase entirely** are cre
 ##### Simple queries
 ```php
 $query = Search::query('clock'); // search by all fields.
-// or 
+// or
 $query = Search::where('name', 'clock'); // search by 'name' field.
 // or
 $query = Search::query('clock')              // search by all fields with
-	->where('short_description', 'analog'); // filter by 'short_description' field. 
+	->where('short_description', 'analog'); // filter by 'short_description' field.
 // or
 $query = Product::search('clock'); // search only in `Product` model by all fields in case when `Product` use `SearchableTrait`.
 ```
@@ -316,12 +316,12 @@ For `query` and `where` methods it is possible to set the following options:
 ###### Examples:
 
 Find all models in which any field contains phrase like 'composite one two phrase':
-```php 
-$query = Search::query('composite phrase', '*', ['proximity' => 2]); 
+```php
+$query = Search::query('composite phrase', '*', ['proximity' => 2]);
 ```
 Search by each word in query:
-```php 
-$query = Search::query('composite phrase', '*', ['phrase' => false]); 
+```php
+$query = Search::query('composite phrase', '*', ['phrase' => false]);
 ```
 
 #### Using Lucene raw queries:
@@ -364,7 +364,7 @@ Highlighting of matches is available for any html fragment encoded in **utf-8** 
 Search::find('nearly all words must be highlighted')->get();
 $highlighted = Search::highlight('all words');
 
-// highlighted html: 
+// highlighted html:
 // '<span class="highlight">all</span> <span class="highlight">words</span>'
 ```
 ##

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "nqxcode/laravel-lucene-search",
-    "description": "Laravel 5.4 package for full-text search over Eloquent models based on ZendSearch Lucene.",
+    "description": "Laravel 5.5 package for full-text search over Eloquent models based on ZendSearch Lucene.",
     "keywords": ["laravel", "lucene", "zendsearch", "eloquent", "search", "fulltext"],
     "license": "MIT",
     "authors": [
@@ -10,16 +10,16 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/support": "5.4.*",
+        "php": ">=7.0",
+        "illuminate/support": "5.5.*",
         "nqxcode/zendsearch": "2.*",
         "nqxcode/lucene-stemmer-en-ru": "1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2",
+        "phpunit/phpunit": "^6.0",
         "mockery/mockery": "0.9.*",
-        "orchestra/testbench": "~3.4.0",
-        "orchestra/database": "~3.4.0"
+        "orchestra/testbench": "~3.5.0",
+        "orchestra/database": "~3.5.0"
     },
     "autoload": {
         "files": [
@@ -28,6 +28,13 @@
         "psr-4": {
             "Nqxcode\\LuceneSearch\\": "src/Nqxcode/LuceneSearch",
             "tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Nqxcode\\LuceneSearch\\ServiceProvider"
+            ]
         }
     },
     "minimum-stability": "stable"

--- a/src/Nqxcode/LuceneSearch/Console/ClearCommand.php
+++ b/src/Nqxcode/LuceneSearch/Console/ClearCommand.php
@@ -13,7 +13,7 @@ class ClearCommand extends Command
     protected $name = 'search:clear';
     protected $description = 'Clear the search index storage';
 
-    public function fire()
+    public function handle()
     {
         if (!$this->option('verbose')) {
             $this->output = new NullOutput;

--- a/src/Nqxcode/LuceneSearch/Console/RebuildCommand.php
+++ b/src/Nqxcode/LuceneSearch/Console/RebuildCommand.php
@@ -17,7 +17,7 @@ class RebuildCommand extends Command
     protected $name = 'search:rebuild';
     protected $description = 'Rebuild the search index';
 
-    public function fire()
+    public function handle()
     {
         if (!$this->option('verbose')) {
             $this->output = new NullOutput;

--- a/src/Nqxcode/LuceneSearch/Highlighting/Highlighter.php
+++ b/src/Nqxcode/LuceneSearch/Highlighting/Highlighter.php
@@ -5,8 +5,6 @@ use ZendSearch\Lucene\Search\Highlighter\HighlighterInterface;
 
 /**
  * Class Highlighter
-/**
- * Class Highlighter
  *
  * Provides a functionality for illumination of words.
  *

--- a/tests/unit/Highlighting/HighlighterTest.php
+++ b/tests/unit/Highlighting/HighlighterTest.php
@@ -15,6 +15,11 @@ class HighlighterTest extends TestCase
         $this->highlighter = new Highlighter();
     }
 
+    public function tearDown()
+    {
+        $this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+    }
+
     public function testHighlight()
     {
         $docMock = m::mock('ZendSearch\Lucene\Document\Html');

--- a/tests/unit/Model/ConfigTest.php
+++ b/tests/unit/Model/ConfigTest.php
@@ -76,7 +76,8 @@ class ConfigTest extends TestCase
     public function testPrimaryKeyPairForIncorrectModel()
     {
         $message = "Configuration doesn't exist for model of class '" . get_class($this->unknownRepoMock) . "'.";
-        $this->setExpectedException('\InvalidArgumentException', $message);
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage($message);
 
         $this->config->primaryKeyPair($this->unknownRepoMock);
     }

--- a/tests/unit/Query/RunnerTest.php
+++ b/tests/unit/Query/RunnerTest.php
@@ -25,6 +25,11 @@ class RunnerTest extends TestCase
         $this->search->shouldReceive('index->find')->with('test')->andReturn([1, 2, 3, 4, 5]);
     }
 
+    public function tearDown()
+    {
+        $this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+    }
+
     public function testRun()
     {
         $this->assertEquals([1, 2, 3, 4, 5], $this->runner->run('test'));


### PR DESCRIPTION
Hi,

This is a port to Laravel 5.5 : 

- Since Laravel 5.5 require PHP >= 7.0, well PHP >= 7.0 is required for this package
- So PHPUnit >= 6 is required and testbench 3.5 (for Laravel 5.5)
- fire() has been rename to handle()
- In Laravel 5.5, there is an "auto discovery" package by adding few lines in composer.json, i just added the service provider (not the facade "Search")
- Minor fixes in tests and a typo in phpdoc ;)

Also, this should fix #59 !

If anything is wrong, tell me ;)

Thanks !